### PR TITLE
DBD Scraping Behavior Fix

### DIFF
--- a/dbd.go
+++ b/dbd.go
@@ -73,7 +73,7 @@ func scrapePerk(perk string) Perk {
 	}
 
 	/** Get Perk Name **/
-	docName := doc.Find(".firstHeading").First()
+	docName := doc.Find("#firstHeading").First()
 	resultingPerk.Name = docName.Text()
 
 	/** Get Description **/

--- a/dbd.go
+++ b/dbd.go
@@ -47,6 +47,7 @@ func formatPerk(command []string) string {
 				words[j] = string(tmp)
 			}
 			command[i] = strings.Join(words, "-")
+			command[i] = strings.Title(command[i])
 		}
 	}
 	perk := strings.Join(command[1:], "_")


### PR DESCRIPTION
- Better capitalization
- Uses an ID rather than a class to find the title of the perk.