### PR TITLE
Integrate periodic-dbd-data into shrine functionality

### DIFF
--- a/dbd_test.go
+++ b/dbd_test.go
@@ -11,18 +11,18 @@ Those commands don't need to be tested since they are verified to work
 at github.com/bwmarrin/discordgo
 **/
 func TestDBD(t *testing.T) {
-	t.Run("Shrine scrapes correctly", func(t *testing.T) {
-		shrine := scrapeShrine()
-		perkCount := 4
-		if len(shrine.Perks) != perkCount || len(shrine.Prices) != perkCount || len(shrine.Owners) != perkCount {
-			t.Logf("Failed to pull the expected %d perks", perkCount)
-			t.Fail()
-		}
-		if shrine.TimeUntilReset == "" {
-			t.Logf("Failed to detect time until shrine resets")
-			t.Fail()
-		}
-	})
+	// t.Run("Shrine scrapes correctly", func(t *testing.T) {
+	// 	shrine := scrapeShrine()
+	// 	perkCount := 4
+	// 	if len(shrine.Perks) != perkCount || len(shrine.Prices) != perkCount || len(shrine.Owners) != perkCount {
+	// 		t.Logf("Failed to pull the expected %d perks", perkCount)
+	// 		t.Fail()
+	// 	}
+	// 	if shrine.TimeUntilReset == "" {
+	// 		t.Logf("Failed to detect time until shrine resets")
+	// 		t.Fail()
+	// 	}
+	// })
 
 	// just using one perk. this will fail if the design scheme for perks
 	// the website changes significantly.


### PR DESCRIPTION
Replace slow and unreliable web scraping for shrine with periodic-dbd-data as a source of information
Replace unreliable go twitter API with periodic-dbd-data to predict incoming shrine changes